### PR TITLE
docs: finalize github project multi-agent operations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Organizar a navegacao da documentacao do RunMate.
 - [Squad Daily Ritual](/Users/user/Desktop/CODE/Run/docs/process/SQUAD_DAILY_RITUAL.md)
 - [GitHub Projects System](/Users/user/Desktop/CODE/Run/docs/process/GITHUB_PROJECTS_SYSTEM.md)
 - [GitHub Projects Visual Guide](/Users/user/Desktop/CODE/Run/docs/process/GITHUB_PROJECTS_VISUAL_GUIDE.md)
+- [Multi-Agent Board Operations](/Users/user/Desktop/CODE/Run/docs/process/MULTI_AGENT_BOARD_OPERATIONS.md)
 - [Git Flow](/Users/user/Desktop/CODE/Run/docs/process/GIT_GITHUB_FLOW.md)
 - [CI/CD Strategy](/Users/user/Desktop/CODE/Run/docs/process/CI_CD_STRATEGY.md)
 

--- a/docs/process/GITHUB_PROJECTS_VISUAL_GUIDE.md
+++ b/docs/process/GITHUB_PROJECTS_VISUAL_GUIDE.md
@@ -9,7 +9,7 @@ Deixar o board do RunMate facil de ler, bonito o suficiente e pratico para opera
 Pontos bons:
 
 - o fluxo principal ja existe
-- as stories da Sprint 3 ja estao no board
+- as historias `US-301` a `US-307` ja estao no board
 - os agentes principais e secundarios ja foram criados
 
 Pontos a melhorar:
@@ -97,17 +97,22 @@ Motivo:
 - tipo: Table
 - filtro: `Sprint = Sprint 3`
 
-### 3. Review and QA
+### 3. Ready Queue
+
+- tipo: Table
+- filtro: `Status = Ready`
+
+### 4. Review and QA
 
 - tipo: Board
 - filtro: `Status = Review` ou `QA`
 
-### 4. Blocked
+### 5. Blocked
 
 - tipo: Table
 - filtro: `Status = Blocked`
 
-### 5. Risk Review
+### 6. Risk Review
 
 - tipo: Table
 - filtro: `Risk != None`
@@ -146,7 +151,7 @@ Se um campo nao ajuda voce a decidir nada em poucos segundos, ele nao deve apare
 ## O que eu mudaria agora no seu board
 
 1. renomear prioridades para `P1 High`, `P2 Medium`, `P3 Low`
-2. criar `Risk`
-3. migrar `Security Impact = Yes` para `Risk = Security`
-4. parar de usar `Blocked` como campo separado
-5. ocultar `Secondary Agent` do card
+2. manter `Risk` como campo unico de alerta
+3. parar de usar qualquer campo separado de bloqueio
+4. criar a view `Ready Queue`
+5. ocultar `Secondary Agent` e `Estimate` do card

--- a/docs/process/MULTI_AGENT_BOARD_OPERATIONS.md
+++ b/docs/process/MULTI_AGENT_BOARD_OPERATIONS.md
@@ -1,0 +1,324 @@
+# Multi-Agent Board Operations - RunMate
+
+## Objetivo
+
+Transformar o `RunMate Delivery Board` em um board operacional real para um squad multi-agent, com dono claro, handoff previsivel e movimentacao consistente dos itens.
+
+## Fonte oficial de operacao
+
+Use sempre esta separacao:
+
+- `GitHub Issues`: unidade de trabalho
+- `GitHub Project`: estado atual da operacao
+- `Repositorio`: contexto, processo, templates e regras
+
+O board deve responder rapidamente:
+
+- quem esta puxando o item
+- em que estado ele esta
+- qual risco principal existe
+- qual agente recebe o proximo handoff
+
+## Setup final do board
+
+### Campos oficiais
+
+Campos que devem continuar como padrao:
+
+- `Status`
+- `Priority`
+- `Sprint`
+- `Primary Agent`
+- `Secondary Agent`
+- `Area`
+- `Estimate`
+- `Risk`
+
+### Views oficiais
+
+O board deve operar com estas views:
+
+1. `Sprint Board`
+   Group by: `Status`
+   Filter: `Sprint = Sprint 3`
+
+2. `Sprint Table`
+   Type: `Table`
+   Filter: `Sprint = Sprint 3`
+
+3. `Ready Queue`
+   Type: `Table`
+   Filter: `Status = Ready`
+
+4. `Review and QA`
+   Type: `Board`
+   Filter: `Status = Review` or `QA`
+
+5. `Blocked`
+   Type: `Table`
+   Filter: `Status = Blocked`
+
+6. `Risk Review`
+   Type: `Table`
+   Filter: `Risk != None`
+
+### Card layout
+
+Deixar visivel no card:
+
+- `Priority`
+- `Sprint`
+- `Primary Agent`
+- `Area`
+- `Risk`
+
+Ocultar do card:
+
+- `Secondary Agent`
+- `Estimate`
+
+## Regra de movimento do item
+
+### Backlog
+
+Usar quando:
+
+- a issue existe, mas ainda nao esta pronta para entrar em execucao
+
+Dono natural:
+
+- `PO`
+
+Proximo handoff:
+
+- `Tech Lead`
+- `UX/UI` quando houver tela ou fluxo novo
+
+### Ready
+
+Usar quando:
+
+- criterio de aceite esta claro
+- risco principal foi identificado
+- area e agentes ja foram definidos
+
+Dono natural:
+
+- `PO`
+
+Proximo handoff:
+
+- `Primary Agent`
+
+### In Progress
+
+Usar quando:
+
+- o agente principal assumiu a implementacao ou analise ativa do item
+
+Dono natural:
+
+- `Primary Agent`
+
+Proximo handoff:
+
+- `Secondary Agent` quando houver dependencia direta
+- `PR Creator` quando houver PR aberta
+
+### Review
+
+Usar quando:
+
+- existe PR aberta
+- a implementacao principal terminou
+
+Dono natural:
+
+- `PR Creator`
+- `Code Review`
+
+Proximo handoff:
+
+- `QA`
+
+### QA
+
+Usar quando:
+
+- a entrega esta pronta para validacao funcional
+
+Dono natural:
+
+- `QA`
+
+Proximo handoff:
+
+- `PM` e `PO` para aceite funcional
+
+### Done
+
+Usar quando:
+
+- PR mergeada
+- validacao concluida
+- sem bloqueio aberto relevante
+
+Dono natural:
+
+- `PM`
+- `PO`
+
+### Blocked
+
+Usar quando:
+
+- existe dependencia tecnica
+- existe falta de definicao
+- existe dependencia entre backend e flutter
+
+Regra obrigatoria:
+
+- atualizar `Risk` com `Dependency`, `Product Clarification` ou `Security`
+
+## Regra de handoff por area
+
+### Product
+
+Fluxo:
+
+`PM -> PO -> Tech Lead`
+
+Entradas:
+
+- objetivo
+- valor
+- prioridade
+
+Saida esperada:
+
+- issue clara e pronta para execucao
+
+### Backend
+
+Fluxo:
+
+`Tech Lead -> Backend Dev -> Security -> PR Creator -> QA`
+
+Quando usar:
+
+- API
+- regra de negocio
+- persistencia
+- auth
+
+### Flutter
+
+Fluxo:
+
+`Tech Lead -> UX/UI -> Flutter Dev -> QA -> PR Creator`
+
+Quando usar:
+
+- tela
+- navegacao
+- estado de sessao
+- integracao mobile
+
+### Security
+
+Fluxo:
+
+entra por gatilho e devolve para:
+
+- `Backend Dev`
+- `Flutter Dev`
+- `Tech Lead`
+
+Quando chamar:
+
+- token
+- secret
+- sessao
+- storage
+- autenticacao
+
+### DevOps
+
+Fluxo:
+
+entra por gatilho e devolve para:
+
+- `Tech Lead`
+- `QA`
+
+Quando chamar:
+
+- CI/CD
+- ambiente
+- release
+- automacao
+
+## Regra de autonomia do time
+
+O time multi-agent nao deve esperar comando humano em cada passo.
+
+Cada agente se move com base nestes gatilhos:
+
+- item em `Ready`: `Primary Agent` assume
+- item em `In Progress` com dependencia clara: chamar `Secondary Agent`
+- PR aberta: mover para `Review`
+- review concluida: mover para `QA`
+- bug ou dependencia real: mover para `Blocked` e atualizar `Risk`
+- merge + validacao: mover para `Done`
+
+## Ordem recomendada de execucao do Sprint 3
+
+Para o board andar com menos bloqueio, usar esta sequencia:
+
+1. `US-301`
+   JWT real no backend
+
+2. `US-302`
+   cadastro real de usuario
+
+3. `US-303`
+   login real
+
+4. `US-304`
+   telas reais de login e cadastro
+
+5. `US-305`
+   integracao Flutter com API real
+
+6. `US-306`
+   persistencia de sessao
+
+7. `US-307`
+   navegacao protegida
+
+## Dependencias operacionais do Sprint 3
+
+- `US-305` depende de `US-301`, `US-302`, `US-303` e `US-304`
+- `US-306` depende de `US-305`
+- `US-307` depende de `US-306`
+
+## Checklist de setup final
+
+- [ ] validar que as 6 views oficiais existem
+- [ ] deixar apenas os 5 campos principais visiveis no card
+- [ ] revisar se todas as issues possuem `Primary Agent`
+- [ ] revisar se todas as issues possuem `Secondary Agent`
+- [ ] revisar se todas as issues possuem `Risk`
+- [ ] confirmar que os itens do Sprint 3 estao em `Sprint = Sprint 3`
+- [ ] usar `Status = Blocked` como unico estado de bloqueio
+- [ ] mover por gatilho, nao por percepcao subjetiva
+
+## Regra de ouro
+
+Se um item esta parado e ninguem sabe quem age agora, o board esta incompleto.
+
+Todo item precisa deixar claro:
+
+- quem esta com a bola
+- quem entra se travar
+- qual e o proximo handoff

--- a/docs/templates/GITHUB_PROJECT_FIELDS.md
+++ b/docs/templates/GITHUB_PROJECT_FIELDS.md
@@ -1,5 +1,32 @@
 # Template - Campos do GitHub Projects
 
+## Estado atual do board
+
+Project atual identificado:
+
+- `RunMate Delivery Board`
+
+Campos que ja existem no project:
+
+- `Status`
+- `Priority`
+- `Sprint`
+- `Primary Agent`
+- `Secondary Agent`
+- `Area`
+- `Estimate`
+- `Risk`
+
+Itens ja presentes no board:
+
+- `US-301`
+- `US-302`
+- `US-303`
+- `US-304`
+- `US-305`
+- `US-306`
+- `US-307`
+
 ## Revisao do modelo
 
 O board deve ser simples de ler e rapido de operar.
@@ -16,7 +43,7 @@ Recomendacao:
 |---|---|---|
 | Status | Single select | estado atual do item |
 | Priority | Single select | prioridade do trabalho |
-| Sprint | Single select | sprint associada |
+| Sprint | Single select | ciclo atual de execucao |
 | Area | Single select | area principal |
 | Primary Agent | Single select | dono principal |
 | Secondary Agent | Single select | agente de apoio |
@@ -109,6 +136,59 @@ Para o board ficar mais legivel:
 - mostrar `Risk`
 
 Evitar mostrar campos demais no card.
+
+## Configuracao operacional recomendada agora
+
+### Views para criar ou validar
+
+- `Sprint Board`
+  Agrupar por `Status`
+  Filtro: `Sprint = Sprint 3`
+
+- `Sprint Table`
+  Tipo `Table`
+  Filtro: `Sprint = Sprint 3`
+
+- `Ready Queue`
+  Tipo `Table`
+  Filtro: `Status = Ready`
+
+- `Review and QA`
+  Tipo `Board`
+  Filtro: `Status = Review` ou `QA`
+
+- `Blocked`
+  Tipo `Table`
+  Filtro: `Status = Blocked`
+
+- `Risk Review`
+  Tipo `Table`
+  Filtro: `Risk != None`
+
+### Campos visiveis no card
+
+Deixar visivel:
+
+- `Priority`
+- `Sprint`
+- `Primary Agent`
+- `Area`
+- `Risk`
+
+Ocultar do card:
+
+- `Secondary Agent`
+- `Estimate`
+
+## Checklist de operacao
+
+- toda issue nova entra com `Priority`, `Area`, `Primary Agent` e `Sprint`
+- issue pronta para ser puxada fica em `Status = Ready`
+- quando alguem assumir, mover para `In Progress`
+- PR aberta move o item para `Review`
+- validacao funcional move para `QA`
+- item travado vai para `Blocked`
+- travou por dependencia ou definicao? atualizar `Risk`
 
 ## Regra pratica
 


### PR DESCRIPTION
## Summary
- align GitHub Project docs with the real RunMate Delivery Board setup
- document the operational views, card layout, and movement rules for the board
- add a multi-agent board operations runbook with handoff rules, owners, and execution order

## Scope
- GitHub Project fields and visual guide
- board operation runbook for multi-agent execution
- docs index update

## Notes
- this PR is focused on operating the board as the source of truth
- issues and GitHub Project remain the execution layer; the repo keeps process and reusable guidance