### PR TITLE
fix: replace /worktree slash command with git worktree commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,17 +64,26 @@ make flutter-test # só testes Flutter
 
 ## Agentes em paralelo (worktrees)
 
-Para trabalhar em múltiplas issues simultaneamente sem conflito de arquivos, use Claude Code com worktrees — um por issue:
+Para trabalhar em múltiplas issues simultaneamente sem conflito de arquivos, crie um worktree git por issue e inicie `claude` dentro de cada um:
 
 ```bash
-# Sessão A: issue #5 (Flutter login screen)
-cd /path/to/Run && claude  # dentro do Claude: /worktree feature/issue-5
+# Criar worktree para a issue #2 (JWT)
+git worktree add .worktrees/issue-2 -b feature/issue-2-jwt
+cd .worktrees/issue-2
+claude   # Claude Code roda isolado nesta branch
 
-# Sessão B: issue #6 (Backend JWT endpoint)
-cd /path/to/Run && claude  # dentro do Claude: /worktree feature/issue-6
+# Em outro terminal, issue #5 em paralelo
+git worktree add .worktrees/issue-5 -b feature/issue-5-telas
+cd .worktrees/issue-5
+claude
 ```
 
-Cada worktree = branch isolada = agente especializado sem sobrescrever o trabalho dos outros.
+Cada worktree = branch isolada = nenhum conflito entre agentes trabalhando ao mesmo tempo.
+
+```bash
+git worktree list                        # ver worktrees ativos
+git worktree remove .worktrees/issue-2   # limpar após o merge
+```
 
 Para ver os agentes disponíveis dentro de qualquer sessão Claude Code, use `/agents`.
 

--- a/docs/process/SPRINT_EXECUTION.md
+++ b/docs/process/SPRINT_EXECUTION.md
@@ -48,19 +48,17 @@ FASE 5 (após #7)                              │
 **Terminal A — issue #2 (JWT)**
 ```bash
 cd /path/to/Run
-claude
-# dentro do Claude:
-# /worktree feature/issue-2-jwt
-# Trabalhar na issue #2 com backend-dev + security
+git worktree add .worktrees/issue-2 -b feature/issue-2-jwt
+cd .worktrees/issue-2
+claude   # agentes: backend-dev + security
 ```
 
 **Terminal B — issue #5 (Telas Flutter)**
 ```bash
 cd /path/to/Run
-claude
-# dentro do Claude:
-# /worktree feature/issue-5-telas
-# Trabalhar na issue #5 com ux-ui + flutter-dev
+git worktree add .worktrees/issue-5 -b feature/issue-5-telas
+cd .worktrees/issue-5
+claude   # agentes: ux-ui + flutter-dev
 ```
 
 ### Fase 2 — após PR #2 mergeado em develop
@@ -68,31 +66,33 @@ claude
 **Terminal C — issue #3 (Cadastro)**
 ```bash
 cd /path/to/Run
-claude
-# /worktree feature/issue-3-cadastro
-# Trabalhar na issue #3 com backend-dev
+git worktree add .worktrees/issue-3 -b feature/issue-3-cadastro
+cd .worktrees/issue-3
+claude   # agente: backend-dev
 ```
 
 **Terminal D — issue #4 (Login)**
 ```bash
 cd /path/to/Run
-claude
-# /worktree feature/issue-4-login
-# Trabalhar na issue #4 com backend-dev
+git worktree add .worktrees/issue-4 -b feature/issue-4-login
+cd .worktrees/issue-4
+claude   # agente: backend-dev
 ```
 
 ### Fases 3, 4, 5 — sequencial (cada uma espera o merge anterior)
 
 ```bash
 # Fase 3 — issue #6
-claude  →  /worktree feature/issue-6-integracao
+git worktree add .worktrees/issue-6 -b feature/issue-6-integracao && cd .worktrees/issue-6 && claude
 
 # Fase 4 — issue #7
-claude  →  /worktree feature/issue-7-persistencia
+git worktree add .worktrees/issue-7 -b feature/issue-7-persistencia && cd .worktrees/issue-7 && claude
 
 # Fase 5 — issue #8
-claude  →  /worktree feature/issue-8-navegacao
+git worktree add .worktrees/issue-8 -b feature/issue-8-navegacao && cd .worktrees/issue-8 && claude
 ```
+
+Após cada merge: `git worktree remove .worktrees/issue-N`
 
 ---
 


### PR DESCRIPTION
## Summary

`/worktree` não existe como slash command no Claude Code. Corrige CLAUDE.md e SPRINT_EXECUTION.md para usar o fluxo correto:

```bash
git worktree add .worktrees/issue-N -b feature/issue-N-nome
cd .worktrees/issue-N
claude
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)