### PR TITLE
feat: implementar cadastro real de usuario no backend

### DIFF
--- a/runmate_backend/src/RunMate.Api/App_Data/.gitignore
+++ b/runmate_backend/src/RunMate.Api/App_Data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/runmate_backend/src/RunMate.Api/Program.cs
+++ b/runmate_backend/src/RunMate.Api/Program.cs
@@ -1,6 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using RunMate.Api.Configuration;
+using RunMate.Application.Auth.Commands;
+using RunMate.Application.Auth.Dtos;
+using RunMate.Application.Auth.Interfaces;
+using RunMate.Application.Auth.Validators;
 using RunMate.Application.Dtos;
+using RunMate.Infrastructure.Persistence;
+using RunMate.Infrastructure.Security;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,9 +20,22 @@ if (!builder.Environment.IsDevelopment() && string.IsNullOrWhiteSpace(jwtSetting
         "JWT secret is missing. Configure Jwt:Secret or JWT__Secret before starting the API.");
 }
 
+var userStoreOptions = builder.Configuration
+    .GetSection(FileUserStoreOptions.SectionName)
+    .Get<FileUserStoreOptions>() ?? new FileUserStoreOptions();
+
+if (!Path.IsPathRooted(userStoreOptions.Path))
+{
+    userStoreOptions.Path = Path.Combine(builder.Environment.ContentRootPath, userStoreOptions.Path);
+}
+
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddSingleton(userStoreOptions);
+builder.Services.AddSingleton<IUserRepository, JsonUserRepository>();
+builder.Services.AddSingleton<IPasswordHashService, Pbkdf2PasswordHashService>();
+builder.Services.AddSingleton<RegisterUserCommandHandler>();
 
 var app = builder.Build();
 
@@ -57,16 +76,34 @@ app.MapGet("/api/workouts", () =>
                 Pace: "5:48/km"),
         }));
 
-app.MapPost("/api/auth/register", ([FromBody] RegisterRequestDto request) =>
+app.MapPost(
+    "/api/auth/register",
+    async (
+        [FromBody] RegisterRequest request,
+        RegisterUserCommandHandler handler,
+        CancellationToken cancellationToken) =>
 {
+    var validationErrors = RegisterRequestValidator.Validate(request);
+    if (validationErrors.Count > 0)
+    {
+        return Results.ValidationProblem(validationErrors);
+    }
+
+    var result = await handler.HandleAsync(request, cancellationToken);
+    if (result.EmailAlreadyExists)
+    {
+        return Results.Conflict(
+            new ProblemDetails
+            {
+                Title = "Email already registered",
+                Detail = "An account with this email already exists.",
+                Status = StatusCodes.Status409Conflict,
+            });
+    }
+
     return Results.Created(
-        "/api/users/me",
-        new
-        {
-            request.Name,
-            request.Email,
-            Message = "Conta criada com sucesso.",
-        });
+        $"/api/users/{result.User!.UserId}",
+        result.User);
 });
 
 app.MapPost("/api/auth/login", ([FromBody] LoginRequestDto request) =>

--- a/runmate_backend/src/RunMate.Api/appsettings.Development.json.example
+++ b/runmate_backend/src/RunMate.Api/appsettings.Development.json.example
@@ -3,6 +3,9 @@
     "Issuer": "RunMate.Api",
     "Audience": "RunMate.Mobile"
   },
+  "UserStore": {
+    "Path": "App_Data/users.json"
+  },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=runmate;Username=postgres;Password=postgres"
   }

--- a/runmate_backend/src/RunMate.Api/appsettings.json
+++ b/runmate_backend/src/RunMate.Api/appsettings.json
@@ -9,5 +9,8 @@
     "Issuer": "RunMate.Api",
     "Audience": "RunMate.Mobile"
   },
+  "UserStore": {
+    "Path": "App_Data/users.json"
+  },
   "AllowedHosts": "*"
 }

--- a/runmate_backend/src/RunMate.Application/Auth/Commands/RegisterUserCommandHandler.cs
+++ b/runmate_backend/src/RunMate.Application/Auth/Commands/RegisterUserCommandHandler.cs
@@ -1,0 +1,51 @@
+using RunMate.Application.Auth.Dtos;
+using RunMate.Application.Auth.Interfaces;
+using RunMate.Domain.Entities;
+
+namespace RunMate.Application.Auth.Commands;
+
+public sealed class RegisterUserCommandHandler
+{
+    private readonly IUserRepository _userRepository;
+    private readonly IPasswordHashService _passwordHashService;
+
+    public RegisterUserCommandHandler(
+        IUserRepository userRepository,
+        IPasswordHashService passwordHashService)
+    {
+        _userRepository = userRepository;
+        _passwordHashService = passwordHashService;
+    }
+
+    public async Task<RegisterUserResult> HandleAsync(
+        RegisterRequest request,
+        CancellationToken cancellationToken)
+    {
+        var user = new User(
+            id: Guid.NewGuid(),
+            name: request.Name.Trim(),
+            email: SanitizeEmail(request.Email),
+            normalizedEmail: NormalizeEmail(request.Email),
+            passwordHash: _passwordHashService.HashPassword(request.Password),
+            createdAtUtc: DateTimeOffset.UtcNow);
+
+        var added = await _userRepository.TryAddAsync(user, cancellationToken);
+        if (!added)
+        {
+            return new RegisterUserResult(User: null, EmailAlreadyExists: true);
+        }
+
+        return new RegisterUserResult(
+            User: new RegisterResponse(
+                UserId: user.Id,
+                Name: user.Name,
+                Email: user.Email),
+            EmailAlreadyExists: false);
+    }
+
+    private static string NormalizeEmail(string email) =>
+        email.Trim().ToUpperInvariant();
+
+    private static string SanitizeEmail(string email) =>
+        email.Trim().ToLowerInvariant();
+}

--- a/runmate_backend/src/RunMate.Application/Auth/Dtos/RegisterResponse.cs
+++ b/runmate_backend/src/RunMate.Application/Auth/Dtos/RegisterResponse.cs
@@ -1,0 +1,6 @@
+namespace RunMate.Application.Auth.Dtos;
+
+public sealed record RegisterResponse(
+    Guid UserId,
+    string Name,
+    string Email);

--- a/runmate_backend/src/RunMate.Application/Auth/Dtos/RegisterUserResult.cs
+++ b/runmate_backend/src/RunMate.Application/Auth/Dtos/RegisterUserResult.cs
@@ -1,0 +1,5 @@
+namespace RunMate.Application.Auth.Dtos;
+
+public sealed record RegisterUserResult(
+    RegisterResponse? User,
+    bool EmailAlreadyExists);

--- a/runmate_backend/src/RunMate.Application/Auth/Interfaces/IUserRepository.cs
+++ b/runmate_backend/src/RunMate.Application/Auth/Interfaces/IUserRepository.cs
@@ -1,0 +1,8 @@
+using RunMate.Domain.Entities;
+
+namespace RunMate.Application.Auth.Interfaces;
+
+public interface IUserRepository
+{
+    Task<bool> TryAddAsync(User user, CancellationToken cancellationToken);
+}

--- a/runmate_backend/src/RunMate.Application/Auth/Validators/RegisterRequestValidator.cs
+++ b/runmate_backend/src/RunMate.Application/Auth/Validators/RegisterRequestValidator.cs
@@ -1,0 +1,93 @@
+using System.Net.Mail;
+using RunMate.Application.Auth.Dtos;
+
+namespace RunMate.Application.Auth.Validators;
+
+public static class RegisterRequestValidator
+{
+    public static Dictionary<string, string[]> Validate(RegisterRequest request)
+    {
+        var errors = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            AddError(errors, nameof(request.Name), "Name is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Email))
+        {
+            AddError(errors, nameof(request.Email), "Email is required.");
+        }
+        else if (!IsValidEmail(request.Email))
+        {
+            AddError(errors, nameof(request.Email), "Email format is invalid.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Password))
+        {
+            AddError(errors, nameof(request.Password), "Password is required.");
+        }
+        else
+        {
+            if (request.Password.Length < 8)
+            {
+                AddError(errors, nameof(request.Password), "Password must be at least 8 characters long.");
+            }
+
+            if (!request.Password.Any(char.IsUpper))
+            {
+                AddError(errors, nameof(request.Password), "Password must contain at least one uppercase letter.");
+            }
+
+            if (!request.Password.Any(char.IsLower))
+            {
+                AddError(errors, nameof(request.Password), "Password must contain at least one lowercase letter.");
+            }
+
+            if (!request.Password.Any(char.IsDigit))
+            {
+                AddError(errors, nameof(request.Password), "Password must contain at least one number.");
+            }
+
+            if (!request.Password.Any(IsSpecialCharacter))
+            {
+                AddError(errors, nameof(request.Password), "Password must contain at least one special character.");
+            }
+        }
+
+        return errors.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.ToArray(),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static void AddError(
+        IDictionary<string, List<string>> errors,
+        string key,
+        string message)
+    {
+        if (!errors.TryGetValue(key, out var messages))
+        {
+            messages = new List<string>();
+            errors[key] = messages;
+        }
+
+        messages.Add(message);
+    }
+
+    private static bool IsValidEmail(string email)
+    {
+        try
+        {
+            _ = new MailAddress(email);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsSpecialCharacter(char character) =>
+        !char.IsLetterOrDigit(character) && !char.IsWhiteSpace(character);
+}

--- a/runmate_backend/src/RunMate.Domain/Entities/User.cs
+++ b/runmate_backend/src/RunMate.Domain/Entities/User.cs
@@ -5,11 +5,23 @@ public sealed class User
     public Guid Id { get; init; }
     public string Name { get; private set; }
     public string Email { get; private set; }
+    public string NormalizedEmail { get; private set; }
+    public string PasswordHash { get; private set; }
+    public DateTimeOffset CreatedAtUtc { get; private set; }
 
-    public User(Guid id, string name, string email)
+    public User(
+        Guid id,
+        string name,
+        string email,
+        string normalizedEmail,
+        string passwordHash,
+        DateTimeOffset createdAtUtc)
     {
         Id = id;
         Name = name;
         Email = email;
+        NormalizedEmail = normalizedEmail;
+        PasswordHash = passwordHash;
+        CreatedAtUtc = createdAtUtc;
     }
 }

--- a/runmate_backend/src/RunMate.Infrastructure/Persistence/FileUserStoreOptions.cs
+++ b/runmate_backend/src/RunMate.Infrastructure/Persistence/FileUserStoreOptions.cs
@@ -1,0 +1,8 @@
+namespace RunMate.Infrastructure.Persistence;
+
+public sealed class FileUserStoreOptions
+{
+    public const string SectionName = "UserStore";
+
+    public string Path { get; set; } = "App_Data/users.json";
+}

--- a/runmate_backend/src/RunMate.Infrastructure/Persistence/JsonUserRepository.cs
+++ b/runmate_backend/src/RunMate.Infrastructure/Persistence/JsonUserRepository.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+using RunMate.Application.Auth.Interfaces;
+using RunMate.Domain.Entities;
+
+namespace RunMate.Infrastructure.Persistence;
+
+public sealed class JsonUserRepository : IUserRepository
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+    };
+
+    private static readonly SemaphoreSlim Mutex = new(1, 1);
+
+    private readonly string _storagePath;
+
+    public JsonUserRepository(FileUserStoreOptions options)
+    {
+        _storagePath = options.Path;
+    }
+
+    public async Task<bool> TryAddAsync(User user, CancellationToken cancellationToken)
+    {
+        await Mutex.WaitAsync(cancellationToken);
+
+        try
+        {
+            var users = await LoadUsersAsync(cancellationToken);
+            if (users.Any(existing =>
+                    string.Equals(existing.NormalizedEmail, user.NormalizedEmail, StringComparison.Ordinal)))
+            {
+                return false;
+            }
+
+            users.Add(new StoredUserRecord(
+                Id: user.Id,
+                Name: user.Name,
+                Email: user.Email,
+                NormalizedEmail: user.NormalizedEmail,
+                PasswordHash: user.PasswordHash,
+                CreatedAtUtc: user.CreatedAtUtc));
+
+            await SaveUsersAsync(users, cancellationToken);
+            return true;
+        }
+        finally
+        {
+            Mutex.Release();
+        }
+    }
+
+    private async Task<List<StoredUserRecord>> LoadUsersAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_storagePath))
+        {
+            return [];
+        }
+
+        await using var stream = File.OpenRead(_storagePath);
+        var users = await JsonSerializer.DeserializeAsync<List<StoredUserRecord>>(
+            stream,
+            SerializerOptions,
+            cancellationToken);
+
+        return users ?? [];
+    }
+
+    private async Task SaveUsersAsync(
+        IReadOnlyCollection<StoredUserRecord> users,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(_storagePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await using var stream = File.Create(_storagePath);
+        await JsonSerializer.SerializeAsync(stream, users, SerializerOptions, cancellationToken);
+    }
+
+    private sealed record StoredUserRecord(
+        Guid Id,
+        string Name,
+        string Email,
+        string NormalizedEmail,
+        string PasswordHash,
+        DateTimeOffset CreatedAtUtc);
+}

--- a/runmate_backend/src/RunMate.Infrastructure/Security/Pbkdf2PasswordHashService.cs
+++ b/runmate_backend/src/RunMate.Infrastructure/Security/Pbkdf2PasswordHashService.cs
@@ -1,0 +1,57 @@
+using System.Security.Cryptography;
+using RunMate.Application.Auth.Interfaces;
+
+namespace RunMate.Infrastructure.Security;
+
+public sealed class Pbkdf2PasswordHashService : IPasswordHashService
+{
+    private const int SaltSize = 16;
+    private const int KeySize = 32;
+    private const int Iterations = 100_000;
+    private const char Separator = '.';
+
+    public string HashPassword(string password)
+    {
+        var salt = RandomNumberGenerator.GetBytes(SaltSize);
+        var hash = Rfc2898DeriveBytes.Pbkdf2(
+            password,
+            salt,
+            Iterations,
+            HashAlgorithmName.SHA256,
+            KeySize);
+
+        return string.Join(
+            Separator,
+            "v1",
+            Iterations,
+            Convert.ToBase64String(salt),
+            Convert.ToBase64String(hash));
+    }
+
+    public bool VerifyPassword(string hashedPassword, string providedPassword)
+    {
+        var parts = hashedPassword.Split(Separator, StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 4 || !int.TryParse(parts[1], out var iterations))
+        {
+            return false;
+        }
+
+        try
+        {
+            var salt = Convert.FromBase64String(parts[2]);
+            var expectedHash = Convert.FromBase64String(parts[3]);
+            var actualHash = Rfc2898DeriveBytes.Pbkdf2(
+                providedPassword,
+                salt,
+                iterations,
+                HashAlgorithmName.SHA256,
+                expectedHash.Length);
+
+            return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Contexto
- A issue #3 pedia substituir o mock de cadastro por um fluxo real no backend, com validacao forte, hash seguro e persistencia de usuario.

Entrega
- troca o POST /api/auth/register por um fluxo real com validacao de nome, e-mail e politica de senha
- normaliza e-mail, bloqueia duplicidade e retorna 409 quando a conta ja existe
- persiste usuarios em arquivo JSON dentro da camada de Infrastructure e retorna resposta sanitizada sem senha ou hash
- adiciona hashing PBKDF2 para senha e prepara o runtime para nao poluir o Git com o arquivo de dados

Escopo fora
- login real
- persistencia em banco relacional
- testes automatizados novos

Validacoes
- revisao manual do diff
- tentativa de `dotnet build RunMate.sln` bloqueada porque `dotnet` nao esta instalado neste ambiente
- tentativa de `dotnet test RunMate.sln` bloqueada porque `dotnet` nao esta instalado neste ambiente

Riscos e pontos de atencao
- a persistencia atual em JSON atende o minimo da story, mas nao substitui banco de dados para cenarios com multiplas instancias ou concorrencia entre processos
- vale revisar o contrato de erro 400/409 com o app quando a integracao real avancar

Proximo handoff
- revisar principalmente o fluxo de cadastro em `Program.cs`, o validator de senha, o hash service e o repositrio JSON

Closes #3